### PR TITLE
Fix iPhone recording issue

### DIFF
--- a/frontend/src/app/RecorderpanelContext.tsx
+++ b/frontend/src/app/RecorderpanelContext.tsx
@@ -23,6 +23,7 @@ import { useSWRMutationHook } from "@/app/hooks/useSWRMutation";
 import { useAlertContext } from "@/app/AlertContext";
 import { useSnackbar } from "@/app/SnackbarContext";
 import { recorderReducer } from "./helpers/recorderReducer";
+import { getMediaRecorderOptions, getBlobPropertyBag, resumeAudioContextForIOS, createAudioBlobUrl } from "./helpers/audioMimeTypes";
 
 export const RecorderPanelContext = createContext<RecorderPanelContextType>({
   recorderState: { status: "idle" },
@@ -38,6 +39,7 @@ export const RecorderPanelContext = createContext<RecorderPanelContextType>({
   isDeleting: false,
   isPracticeRecording: false,
   setIsPracticeRecording: () => {},
+  recordingCountdown: null,
 });
 
 interface RecorderPanelContextProviderProps {
@@ -72,6 +74,7 @@ export default function RecorderPanelContextProvider({
     status: "idle",
   });
   const [isPracticeRecording, setIsPracticeRecording] = useState(false);
+  const [recordingCountdown, setRecordingCountdown] = useState<number | null>(null);
 
   // react-media-recorder hook handles all the browser MediaRecorder complexity
   const {
@@ -83,19 +86,44 @@ export default function RecorderPanelContextProvider({
     error,
   } = useReactMediaRecorder({
     audio: true,
+    blobPropertyBag: getBlobPropertyBag(),
+    mediaRecorderOptions: getMediaRecorderOptions(),
     onStop: (blobUrl, blob) => {
-      dispatch({ type: "STOP_RECORDING", blob, audioURL: blobUrl });
+      // Create iPhone-compatible blob URL with proper MIME type
+      const compatibleBlobUrl = blob ? createAudioBlobUrl(blob) : blobUrl;
+      dispatch({ type: "STOP_RECORDING", blob, audioURL: compatibleBlobUrl });
     },
   });
 
-  const startRecording = useCallback(() => {
+  const startRecording = useCallback(async () => {
     if (error) {
       logger.error("Error accessing microphone:", error);
       openAlertDialog(t("microphoneError"), t("microphoneErrorMessage"));
       return;
     }
+
+    // iOS Safari fix: Resume audio context on user gesture
+    try {
+      await resumeAudioContextForIOS();
+    } catch (error) {
+      console.warn("Could not resume audio context:", error);
+    }
+
+    // Start recording immediately but show countdown for when to speak
     startMediaRecording();
     dispatch({ type: "START_RECORDING", startedAt: Date.now() });
+
+    // Start countdown to tell user when to speak (Safari/iPhone needs time)
+    setRecordingCountdown(1);
+    const countdownTimer = setInterval(() => {
+      setRecordingCountdown(prev => {
+        if (prev === null || prev <= 1) {
+          clearInterval(countdownTimer);
+          return null;
+        }
+        return prev - 1;
+      });
+    }, 1000);
   }, [startMediaRecording, error, openAlertDialog, t]);
 
   const pauseRecording = useCallback(() => {
@@ -110,6 +138,7 @@ export default function RecorderPanelContextProvider({
 
   const stopRecording = useCallback(() => {
     stopMediaRecording();
+    setRecordingCountdown(null);
   }, [stopMediaRecording]);
 
   const handleSubmit = useCallback(async () => {
@@ -219,6 +248,7 @@ export default function RecorderPanelContextProvider({
       isDeleting,
       isPracticeRecording,
       setIsPracticeRecording,
+      recordingCountdown,
     }),
     [
       recorderState,
@@ -232,6 +262,7 @@ export default function RecorderPanelContextProvider({
       isLessonMutating,
       isDeleting,
       isPracticeRecording,
+      recordingCountdown,
     ]
   );
 

--- a/frontend/src/app/Types.ts
+++ b/frontend/src/app/Types.ts
@@ -141,6 +141,7 @@ export interface RecorderPanelContextType {
   isDeleting: boolean;
   isPracticeRecording: boolean;
   setIsPracticeRecording: (value: boolean) => void;
+  recordingCountdown: number | null;
 }
 
 export interface List {

--- a/frontend/src/app/components/media/RecorderVoiceRecorder.tsx
+++ b/frontend/src/app/components/media/RecorderVoiceRecorder.tsx
@@ -14,6 +14,7 @@ export default function RecorderVoiceRecorder() {
     resumeRecording,
     stopRecording,
     isPracticeRecording,
+    recordingCountdown,
   } = useRecorderPanelContext();
 
   const isRecording = recorderState.status === "recording";
@@ -34,6 +35,18 @@ export default function RecorderVoiceRecorder() {
         <Typography variant="body2" color="text.secondary">
           {isRecording && t("recordingInProgress")}
           {isPaused && t("recordingPaused")}
+        </Typography>
+      )}
+      {recordingCountdown && recordingCountdown > 0 && (
+        <Typography
+          variant="h6"
+          color="primary"
+          sx={{
+            fontWeight: "bold",
+            textAlign: "center"
+          }}
+        >
+          Speak in {recordingCountdown}...
         </Typography>
       )}
 

--- a/frontend/src/app/components/ui/PracticeCard.tsx
+++ b/frontend/src/app/components/ui/PracticeCard.tsx
@@ -68,6 +68,7 @@ export default function PracticeCard({
     speechRate,
     speak,
     listenToSegment,
+    recordingCountdown,
   } = usePracticeCard({
     text: plainText,
     nativeLanguage,
@@ -109,6 +110,7 @@ export default function PracticeCard({
           handleSpeak={handleSpeak}
           t={t}
           mediaBlobUrl={mediaBlobUrl}
+          recordingCountdown={recordingCountdown}
         />
 
         <PracticeCardSpeedControl

--- a/frontend/src/app/components/ui/PracticeCardActions.tsx
+++ b/frontend/src/app/components/ui/PracticeCardActions.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { FiMic, FiSquare, FiVolume2 } from "react-icons/fi";
 
 interface PracticeCardActionsProps {
@@ -12,6 +12,7 @@ interface PracticeCardActionsProps {
   speechRate: number;
   t: (key: string) => string;
   mediaBlobUrl?: string | null;
+  recordingCountdown?: number | null;
 }
 
 export default function PracticeCardActions({
@@ -25,6 +26,7 @@ export default function PracticeCardActions({
   handleSpeak,
   t,
   mediaBlobUrl,
+  recordingCountdown,
 }: PracticeCardActionsProps) {
   return (
     <Box
@@ -69,6 +71,20 @@ export default function PracticeCardActions({
             ? t("evaluating")
             : t("speak")}
       </Button>
+      {recordingCountdown && recordingCountdown > 0 && (
+        <Typography
+          variant="h6"
+          color="primary"
+          sx={{
+            fontWeight: "bold",
+            alignSelf: "center",
+            minWidth: "60px",
+            textAlign: "center"
+          }}
+        >
+          Speak in {recordingCountdown}...
+        </Typography>
+      )}
       {mediaBlobUrl && status !== "recording" && (
         <Box
           playsInline

--- a/frontend/src/app/helpers/audioMimeTypes.ts
+++ b/frontend/src/app/helpers/audioMimeTypes.ts
@@ -1,0 +1,45 @@
+/**
+ * Cross-platform audio recording with iOS/iPhone support
+ * Based on Gemini's recommendation for iPhone compatibility
+ */
+
+// Gemini's universal MIME type detection - audio version
+export const getSupportedMimeType = () => {
+  const types = [
+    'audio/mp4',                // Top pick for iOS/Safari
+    'audio/webm;codecs=opus',   // Top pick for Chrome/Android/PC
+    'audio/webm',              // Chrome fallback
+    'audio/mpeg'               // iOS fallback
+  ];
+  return types.find(type => MediaRecorder.isTypeSupported(type)) || '';
+};
+
+// Gemini's complete recorder configuration
+export const getMediaRecorderOptions = () => {
+  const mimeType = getSupportedMimeType();
+  return mimeType ? { mimeType } : undefined;
+};
+
+export const getBlobPropertyBag = () => {
+  const mimeType = getSupportedMimeType();
+  return mimeType ? { type: mimeType } : undefined;
+};
+
+// Gemini's iOS audio context fix
+export const resumeAudioContextForIOS = async () => {
+  // Safari fix: Resume audio context on user gesture
+  if (window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext) {
+    const AudioCtx = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    const context = new AudioCtx();
+    if (context.state === 'suspended') {
+      await context.resume();
+    }
+  }
+};
+
+// Create blob URL with proper MIME type for iPhone compatibility
+export const createAudioBlobUrl = (blob: Blob) => {
+  const mimeType = getSupportedMimeType();
+  const audioBlob = new Blob([blob], { type: mimeType });
+  return URL.createObjectURL(audioBlob);
+};

--- a/frontend/src/app/hooks/usePracticeCard.ts
+++ b/frontend/src/app/hooks/usePracticeCard.ts
@@ -10,12 +10,7 @@ import { API_PATHS } from "../constants/apiKeys";
 import { useReactMediaRecorder } from "react-media-recorder";
 import api from "../helpers/axiosFetch";
 import { useRecorderPanelContext } from "../RecorderpanelContext";
-
-const safariMimeType =
-  typeof MediaRecorder !== "undefined" &&
-  MediaRecorder.isTypeSupported("audio/mp4")
-    ? "audio/mp4"
-    : undefined;
+import { getMediaRecorderOptions, getBlobPropertyBag, resumeAudioContextForIOS } from "../helpers/audioMimeTypes";
 
 export default function usePracticeCard({
   text,
@@ -29,6 +24,7 @@ export default function usePracticeCard({
   const [speechRate, setSpeechRate] = useState(0.9);
   const [displayedEvaluation, setDisplayedEvaluation] =
     useState<EvaluationResult | null>(initialEvaluation ?? null);
+  const [recordingCountdown, setRecordingCountdown] = useState<number | null>(null);
 
   const segmentAudioRef = useRef<HTMLAudioElement | null>(null);
   const { speak } = useSpeakMutation();
@@ -118,18 +114,41 @@ export default function usePracticeCard({
     useReactMediaRecorder({
       audio: true,
       onStop: handleRecordingStop,
-      ...(safariMimeType && { mediaRecorderOptions: { mimeType: safariMimeType } }),
+      blobPropertyBag: getBlobPropertyBag(),
+      mediaRecorderOptions: getMediaRecorderOptions(),
     });
 
-  function handleSpeak() {
+  async function handleSpeak() {
     if (status === "recording") {
       stopRecording();
       setIsPracticeRecording(false);
+      setRecordingCountdown(null);
     } else {
+      // iOS Safari fix: Resume audio context on user gesture
+      try {
+        await resumeAudioContextForIOS();
+      } catch (error) {
+        console.warn("Could not resume audio context:", error);
+      }
+
       resetEvaluation();
       setDisplayedEvaluation(null);
       setIsPracticeRecording(true);
+
+      // Start recording immediately but show countdown for when to speak
       startRecording();
+
+      // Start countdown to tell user when to speak
+      setRecordingCountdown(1);
+      const countdownTimer = setInterval(() => {
+        setRecordingCountdown(prev => {
+          if (prev === null || prev <= 1) {
+            clearInterval(countdownTimer);
+            return null;
+          }
+          return prev - 1;
+        });
+      }, 1000);
     }
   }
 
@@ -151,5 +170,6 @@ export default function usePracticeCard({
     speak,
     listenToSegment: audioSegment ? listenToSegment : undefined,
     isLessonRecording,
+    recordingCountdown,
   };
 }


### PR DESCRIPTION
  - Add cross-platform MIME type detection (audio/mp4 for Safari/iPhone, audio/webm for others)
  - Implement 1-second recording countdown to fix Safari's MediaRecorder initialization delay
  - Apply fix to both practice card recorder and main lesson recorder
  - Add iOS AudioContext resume for better Safari compatibility
  - Create proper blob URLs with correct MIME types for playback
