### PR TITLE
Add logging for iphone audio recording issues

### DIFF
--- a/backend/services/speechEvaluation.ts
+++ b/backend/services/speechEvaluation.ts
@@ -130,8 +130,19 @@ export async function evaluatePronunciation(
   audioBuffer: Buffer,
   referenceText: string
 ) {
+  // Log original audio details for debugging iPhone issues
+  const originalFormat = detectAudioFormat(audioBuffer);
+  console.log(`[DEBUG] Audio evaluation - Original: ${audioBuffer.length} bytes, format: ${originalFormat}`);
+
   // Convert webm to WAV for Azure
   const wavBuffer = await convertToWav(audioBuffer);
+  console.log(`[DEBUG] Audio evaluation - Converted WAV: ${wavBuffer.length} bytes`);
+
+  // Log potential issues with short audio
+  if (wavBuffer.length < 8000) { // Less than ~0.25 seconds of 16kHz mono PCM
+    console.warn(`[WARNING] Very short audio detected: ${wavBuffer.length} bytes - may cause evaluation issues`);
+  }
+
   const speechConfig = sdk.SpeechConfig.fromSubscription(speechKey, speechRegion);
   speechConfig.speechRecognitionLanguage = "en-US";
 
@@ -158,6 +169,14 @@ export async function evaluatePronunciation(
         if (result.reason === sdk.ResultReason.RecognizedSpeech) {
           const pronunciationResult =
             sdk.PronunciationAssessmentResult.fromResult(result);
+
+          // Log evaluation results for debugging
+          console.log(`[DEBUG] Azure evaluation successful - Text: "${result.text}", Accuracy: ${pronunciationResult.accuracyScore}, Reference: "${referenceText}"`);
+
+          // Check if recognized text is suspiciously short compared to reference
+          if (result.text.length < referenceText.length * 0.3) {
+            console.warn(`[WARNING] Recognized text much shorter than reference - may indicate partial audio. Got: "${result.text}", Expected: "${referenceText}"`);
+          }
 
           resolve({
             text: result.text,

--- a/frontend/src/app/RecorderpanelContext.tsx
+++ b/frontend/src/app/RecorderpanelContext.tsx
@@ -24,6 +24,7 @@ import { useAlertContext } from "@/app/AlertContext";
 import { useSnackbar } from "@/app/SnackbarContext";
 import { recorderReducer } from "./helpers/recorderReducer";
 import { getMediaRecorderOptions, getBlobPropertyBag, resumeAudioContextForIOS, createAudioBlobUrl } from "./helpers/audioMimeTypes";
+import * as Sentry from "@sentry/nextjs";
 
 export const RecorderPanelContext = createContext<RecorderPanelContextType>({
   recorderState: { status: "idle" },
@@ -89,6 +90,39 @@ export default function RecorderPanelContextProvider({
     blobPropertyBag: getBlobPropertyBag(),
     mediaRecorderOptions: getMediaRecorderOptions(),
     onStop: (blobUrl, blob) => {
+      // Log audio recording details for debugging iPhone issues
+      const userAgent = navigator.userAgent;
+      const isIOS = /iPad|iPhone|iPod/.test(userAgent);
+      const isSafari = /Safari/.test(userAgent) && !/Chrome/.test(userAgent);
+      const isInAppBrowser = /FBAN|FBAV|Instagram|LinkedIn|Twitter|WhatsApp/.test(userAgent);
+
+      Sentry.addBreadcrumb({
+        category: "audio.recording",
+        message: "Recording stopped",
+        data: {
+          blobSize: blob?.size || 0,
+          blobType: blob?.type || "unknown",
+          hasBlob: !!blob,
+          hasBlobUrl: !!blobUrl,
+          isIOS,
+          isSafari,
+          isInAppBrowser,
+          userAgent
+        },
+        level: "info"
+      });
+
+      if (blob && blob.size === 0) {
+        Sentry.captureMessage("Empty audio blob detected on recording stop", {
+          tags: {
+            device: isIOS ? "iOS" : "other",
+            browser: isSafari ? "Safari" : "other",
+            inAppBrowser: isInAppBrowser
+          },
+          extra: { userAgent, blobSize: 0 }
+        });
+      }
+
       // Create iPhone-compatible blob URL with proper MIME type
       const compatibleBlobUrl = blob ? createAudioBlobUrl(blob) : blobUrl;
       dispatch({ type: "STOP_RECORDING", blob, audioURL: compatibleBlobUrl });
@@ -164,6 +198,19 @@ export default function RecorderPanelContextProvider({
         }
 
         try {
+          // Log audio submission details for debugging
+          const audioSizeKB = Math.round((base64Audio.length * 3) / 4 / 1024);
+          Sentry.addBreadcrumb({
+            category: "audio.upload",
+            message: "Submitting audio for evaluation",
+            data: {
+              audioSizeKB,
+              lessonId: selectedLesson.id,
+              blobSize: recorderState.blob?.size || 0
+            },
+            level: "info"
+          });
+
           const uploadResponse = await triggerUploadAudio({
             audioData: base64Audio,
             lessonId: selectedLesson.id,


### PR DESCRIPTION
  Add logging for iPhone audio recording issues
- Add Sentry logging in RecorderPanelContext for empty audio blobs
- Log device/browser detection (iOS/Safari/in-app browsers)
- Add server-side audio buffer size and format logging
- Log Azure evaluation results vs expected text
- Warn on suspiciously short audio that may indicate partial recordings