### PR TITLE
fix: remove leftover @sentry/node usage in backend (fixes prod build)

### DIFF
--- a/backend/handlers/handleError.ts
+++ b/backend/handlers/handleError.ts
@@ -1,6 +1,5 @@
 import logger from "../helpers/logger.js";
 import { Request, Response, NextFunction } from "express";
-import * as Sentry from "@sentry/node";
 
 export default function handleError(
   err: Error & { status?: number },
@@ -9,7 +8,6 @@ export default function handleError(
   _next: NextFunction
 ) {
   logger.error(err.stack);
-  Sentry.captureException(err);
   if (err.status) {
     res.status(err.status).json({
       success: false,

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,10 +1,3 @@
-import * as Sentry from "@sentry/node";
-
-Sentry.init({
-  dsn: "https://17f38e802245fea7ad697ee24ba11f04@o4510629644140544.ingest.us.sentry.io/4510629804048384",
-  sendDefaultPii: true,
-});
-
 import * as dotenv from "dotenv";
 if (process.env.NODE_ENV !== "production") {
   dotenv.config();


### PR DESCRIPTION
## Urgent — fixes broken production build

#300 removed the `@sentry/node` dependency, but two backend source files still imported it, so the Render build now fails:

```
handlers/handleError.ts(3,25): error TS2307: Cannot find module '@sentry/node'
index.ts(1,25): error TS2307: Cannot find module '@sentry/node'
```

(The backend code lives in `backend/handlers/` and `backend/index.ts`, not `backend/src/`, which is why these were missed in #300.)

## Fix
- `index.ts` — removed `Sentry.init(...)` + import
- `handlers/handleError.ts` — removed `Sentry.captureException(err)` + import; errors are still logged via the existing `logger.error(err.stack)`

## Verification
- `npm run build` (the exact command Render runs) → passes, exit 0