### PR TITLE
🐛 remount review player per lesson so seek works without a hard refresh

### DIFF
--- a/frontend/src/app/components/media/RecorderAudioplayer.tsx
+++ b/frontend/src/app/components/media/RecorderAudioplayer.tsx
@@ -13,6 +13,7 @@ export default function RecorderAudioPlayer({
   const { recorderState } = useRecorderPanelContext();
   const audioURL =
     recorderState.status === "stopped" ? recorderState.audioURL : null;
+  const audioSrc = selectedLesson?.audio_file || audioURL || "";
 
   const playerRef = useRef<AudioPlayer>(null);
 
@@ -40,8 +41,9 @@ export default function RecorderAudioPlayer({
   return (
     <Box>
       <AudioPlayer
+        key={audioSrc}
         ref={playerRef}
-        src={selectedLesson?.audio_file || audioURL || ""}
+        src={audioSrc}
         showJumpControls={false}
         onLoadedMetaData={handleLoadedMetadata}
       />


### PR DESCRIPTION
react-h5-audio-player reuses the same <audio> element across src changes, so switching lessons carried stale duration state and the webm prime never re-ran — seeking only worked after a manual hard refresh. Key the player to the audio source so each lesson mounts a fresh player (and re-runs the prime), matching the hard-refresh behavior automatically. Key is on the player only; the submit/delete buttons and the upload flow (which reads the raw Blob from context, not the player) are unaffected.

## What changed

  <!-- One sentence. What does this PR do? -->

## Closes

Closes #<!-- issue number -->

## How to test

  <!-- Steps to verify this works in the browser -->

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Tested in the browser
- [ ] No `console.log` left in the code
