### PR TITLE
⏪ revert RecorderAudioPlayer to original (undo #302 and #303)

### DIFF
--- a/frontend/src/app/components/media/RecorderAudioplayer.tsx
+++ b/frontend/src/app/components/media/RecorderAudioplayer.tsx
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import { Lesson } from "@/app/Types";
 import AudioPlayer from "react-h5-audio-player";
 import RecorderAudioButtons from "./RecorderAudioButtons";
@@ -13,39 +12,12 @@ export default function RecorderAudioPlayer({
   const { recorderState } = useRecorderPanelContext();
   const audioURL =
     recorderState.status === "stopped" ? recorderState.audioURL : null;
-  const audioSrc = selectedLesson?.audio_file || audioURL || "";
-
-  const playerRef = useRef<AudioPlayer>(null);
-
-  // Raw MediaRecorder .webm recordings are uploaded without duration metadata,
-  // so the browser reports `duration === Infinity` and the file is not seekable —
-  // clicking the progress bar snaps playback back to 0. Force the browser to scan
-  // to the end once so it learns the real duration, then reset to the start; after
-  // that the file seeks normally. This is a no-op for recordings that already have
-  // a finite duration (e.g. Safari .mp4), so existing recordings are untouched.
-  function handleLoadedMetadata() {
-    const audio = playerRef.current?.audio.current;
-    if (!audio || Number.isFinite(audio.duration)) return;
-
-    const resolveDuration = () => {
-      if (Number.isFinite(audio.duration)) {
-        audio.removeEventListener("durationchange", resolveDuration);
-        audio.currentTime = 0;
-      }
-    };
-
-    audio.addEventListener("durationchange", resolveDuration);
-    audio.currentTime = 1e101;
-  }
 
   return (
     <Box>
       <AudioPlayer
-        key={audioSrc}
-        ref={playerRef}
-        src={audioSrc}
+        src={selectedLesson?.audio_file || audioURL || ""}
         showJumpControls={false}
-        onLoadedMetaData={handleLoadedMetadata}
       />
       <RecorderAudioButtons selectedLesson={selectedLesson} />
     </Box>


### PR DESCRIPTION
The webm duration-prime (#302) and per-lesson remount (#303) did not fix seeking and degraded the loading behavior. Restore the original player.

## What changed

  <!-- One sentence. What does this PR do? -->

## Closes

Closes #<!-- issue number -->

## How to test

  <!-- Steps to verify this works in the browser -->

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Tested in the browser
- [ ] No `console.log` left in the code
