### PR TITLE
fix: transcode student webm to seekable mp3 via Cloudinary fetch in r…

### DIFF
--- a/frontend/src/app/components/teacher/TeacherLessonDetails.tsx
+++ b/frontend/src/app/components/teacher/TeacherLessonDetails.tsx
@@ -49,6 +49,8 @@ export default function TeacherLessonDetails({
 
   if (!selectedLesson) return null;
 
+  const cloud = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+  const seekableSrc = `https://res.cloudinary.com/${cloud}/video/fetch/f_mp3/${selectedLesson.audio_file}`;
   const hasSubmission =
     selectedLesson.status === "submitted" ||
     selectedLesson.status === "completed";
@@ -83,7 +85,7 @@ export default function TeacherLessonDetails({
       >
         {t("studentRecording")}
       </Typography>
-      <AudioPlayer src={selectedLesson.audio_file} showJumpControls={false} />
+      <AudioPlayer src={seekableSrc} showJumpControls={false} />
     </Paper>
   ) : (
     <Paper


### PR DESCRIPTION
 Fix: teacher review audio bar jumps back to start

  Problem
  On the teacher review page, dragging the audio seek bar on a student's recording jumped back to 0 instead of moving to where you clicked. Sometimes worked after a
  refresh, sometimes didn't.

  Why
  Student recordings are .webm files from the browser's recorder, which don't have a seek index in them. So the browser can't jump to a spot — the file plays fine start
  to finish but isn't seekable.

  Fix
  Run the audio through Cloudinary's fetch URL (/video/fetch/f_mp3/), which converts it to mp3 on the fly. mp3 is seekable, so the bar works now. Nothing moved — the
  files still live on Azure, Cloudinary just converts them when the teacher plays them. Works for old and new recordings.
